### PR TITLE
Chore: 로컬/배포 환경 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# 배포용 설정 파일 제외
+src/main/resources/application-prod.properties

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,9 @@
+# 데이터베이스 연결 정보(윤디비 과제 하셨으면 username, password 아래와 같을 겁니다)
+spring.datasource.url=jdbc:postgresql://localhost:5432/cherrymap
+spring.datasource.username=postgres
+spring.datasource.password=1234
+# 개발 환경에서 ddl-auto 설정
+spring.jpa.hibernate.ddl-auto=update
+
+# 카카오 리다이렉션 URL
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/login/oauth2/code/kakao

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,17 +1,27 @@
 # Spring Boot 애플리케이션 이름
 spring.application.name=cherrymap
 
+# 기본 활성화 프로파일 (로컬 환경: dev, 배포: prod)
+spring.profiles.active=dev
+
 # PostgreSQL 데이터베이스 연결 정보
-spring.datasource.url=jdbc:postgresql://postgres-container:5432/cherrymap
-spring.datasource.username=untitled
-spring.datasource.password=1234
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JPA 설정
 spring.jpa.database=postgresql
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 
-# Spring security 비활성화
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+# ============ Spring Security + OAuth2 (카카오) ============
+# 카카오 인증 정보를 등록 (client-id, redirect-uri 등)의
+spring.security.oauth2.client.registration.kakao.client-id=8fd4aaff28f77c88ec353aef5aa238ce
+spring.security.oauth2.client.registration.kakao.client-secret=
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.client-name=Kakao
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname, account_email
+
+# 카카오 API 엔드포인트 (provider)
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id


### PR DESCRIPTION
## #️⃣연관된 이슈

> 로컬/배포 환경 분리(application.properties 수정) #2

## 📝작업 내용

> DB 연결, 카카오 로그인 API 연결 등 기능 구현 테스트 편의를 위해 로컬/배포 환경 설정을 분리
- 공통 설정 / 세부 설정 내용 분리
- `application.properties`(공통 설정)
- `application-dev.properties`(로컬 개발용)
- `application-prod.properties`(배포용)-`.gitignore`에 추가하여 dev 브랜치에는 올라가지 않을 것임.