### PR TITLE
Feat: 카카오 로그인 API 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.security:spring-security-oauth2-jose'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/untitled/cherrymap/config/SecurityConfig.java
+++ b/src/main/java/com/untitled/cherrymap/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com.untitled.cherrymap.config;
+
+import com.untitled.cherrymap.service.KakaoOAuth2MemberService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    private final KakaoOAuth2MemberService kakaoOAuth2MemberService;
+
+    public SecurityConfig(KakaoOAuth2MemberService kakaoOAuth2MemberService) {
+        this.kakaoOAuth2MemberService = kakaoOAuth2MemberService;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf
+                        .ignoringRequestMatchers("/login/oauth2/**", "/api/**") // 특정 경로만 제외
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/", "/login/oauth2/code/kakao", "/error").permitAll() // 인증 불필요 경로
+                        .anyRequest().authenticated() // 나머지 경로는 인증 필요
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(kakaoOAuth2MemberService) // 사용자 정보 처리
+                        )
+                        .successHandler((request, response, authentication) -> {
+                            OAuth2User user = (OAuth2User) authentication.getPrincipal();
+                            String memberId = user.getAttribute("id"); // 사용자 고유 ID: memberId(카카오에서 제공)
+                            response.sendRedirect("/" + memberId + "/home");
+                        })
+
+                ).logout(logout -> logout
+                        .logoutUrl("/logout") // 로그아웃 엔드포인트
+                        .logoutSuccessUrl("/logout-success") // 로그아웃 성공 후 리다이렉트 경로
+                        .invalidateHttpSession(true) // 세션 무효화
+                        .deleteCookies("JSESSIONID") // 쿠키 삭제
+                        .permitAll() // 모든 사용자 접근 허용
+                );
+        return http.build();
+    }
+}

--- a/src/main/java/com/untitled/cherrymap/controller/FrontendApiController.java
+++ b/src/main/java/com/untitled/cherrymap/controller/FrontendApiController.java
@@ -1,0 +1,38 @@
+package com.untitled.cherrymap.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class FrontendApiController {
+
+    private final MemberRepository memberRepository;
+
+    public FrontendApiController(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @GetMapping("/{memberId}/info")
+    public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal OAuth2User user) {
+        if (user == null) {
+            return ResponseEntity.badRequest().body("User not authenticated");
+        }
+
+        String providerId = user.getAttribute("id");
+        Member member = memberRepository.findByProviderId(providerId);
+
+        if (member == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(Map.of(
+                "nickname", member.getNickname(),
+                "email", member.getEmail()
+        ));
+    }
+}

--- a/src/main/java/com/untitled/cherrymap/controller/ThymeleafTestController.java
+++ b/src/main/java/com/untitled/cherrymap/controller/ThymeleafTestController.java
@@ -1,0 +1,34 @@
+package com.untitled.cherrymap.controller;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+// 웹브라우저를 통한 카카오 로그인 api 테스트 목적으로 만든 테스트용 컨트롤러(프론트에 제공하지 않음)
+@Controller
+@Profile("dev") // 개발 환경에서만 활성화
+public class ThymeleafTestController {
+
+    @GetMapping("/{memberId}/home")
+    public String testHomePage(Model model, @AuthenticationPrincipal OAuth2User user) {
+        System.out.println("User Attributes: " + user.getAttributes()); // 전체 속성 출력 for logging
+        String nickname = user.getAttribute("nickname");
+        String email = user.getAttribute("email");
+
+        System.out.println("Nickname: " + nickname); // 닉네임 출력 for logging
+        System.out.println("Email: " + email);       // 이메일 출력 for logging
+
+        model.addAttribute("nickname", nickname);
+        model.addAttribute("email", email);
+        return "home"; // home.html 렌더링
+    }
+
+    @GetMapping("/logout-success")
+    public String logoutSuccess() {
+        return "logout"; // logout.html 렌더링
+    }
+}
+

--- a/src/main/java/com/untitled/cherrymap/service/KakaoOAuth2MemberService.java
+++ b/src/main/java/com/untitled/cherrymap/service/KakaoOAuth2MemberService.java
@@ -1,0 +1,67 @@
+package com.untitled.cherrymap.service;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import java.util.Map;
+
+@Service
+public class KakaoOAuth2MemberService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    public KakaoOAuth2MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // 카카오 계정 정보 추출
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = kakaoAccount != null ? (Map<String, Object>) kakaoAccount.get("profile") : null;
+
+        String providerId = attributes.getOrDefault("id", "Unknown").toString();
+        String nickname = profile != null ? profile.getOrDefault("nickname", "Unknown").toString() : "Unknown";
+        String email = kakaoAccount != null ? kakaoAccount.getOrDefault("email", "Unknown").toString() : "Unknown";
+
+        // 이메일 검증
+        if (email.equals("Unknown")) {
+            throw new IllegalArgumentException("이메일 정보가 없습니다.");
+        }
+
+        // User 저장 또는 업데이트
+        Member member = memberRepository.findByProviderId(providerId);
+        if (member == null) {
+            member = Member.builder()
+                    .providerId(providerId)
+                    .nickname(nickname)
+                    .email(email)
+                    .build();
+            System.out.println("새 사용자 등록: " + nickname + " (" + email + ")");
+        } else {
+            member.setNickname(nickname);
+            member.setEmail(email);
+            System.out.println("기존 사용자 업데이트: " + nickname + " (" + email + ")");
+        }
+        memberRepository.save(member);
+
+        // 사용자 정보를 DefaultOAuth2User로 반환
+        Map<String, Object> customAttributes = Map.of(
+                "id", providerId,
+                "nickname", member.getNickname(),
+                "email", member.getEmail()
+        );
+
+        return new DefaultOAuth2User(
+                oAuth2User.getAuthorities(),
+                customAttributes,
+                "id"
+        );
+    }
+}
+
+

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,0 +1,13 @@
+<!-- 백엔드 카카오 로그인 api 테스트 용 페이지 2 -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Home</title>
+</head>
+<body>
+  <h1>Welcome, <span th:text="${nickname}">[nickname is empty]</span>!</h1>
+  <p>Your email is: <span th:text="${email}">[email is empty]</span></p>
+</body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,23 @@
+<!-- 백엔드 카카오 로그인 api 테스트 용 페이지 1 -->
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+</head>
+<body>
+    <h1>카카오 로그인</h1>
+    <a href="/oauth2/authorization/kakao">
+        <button>카카오로 로그인</button>
+    </a>
+    <!-- 로그인 오류 메시지 표시 -->
+    <div style="color: red; margin-top: 20px;">
+        <!-- Spring Security가 "error" 쿼리 파라미터를 추가 -->
+        <script>
+            const params = new URLSearchParams(window.location.search);
+            if (params.has("error")) {
+                document.write("<p>로그인 실패: 인증에 실패했습니다. 다시 시도해주세요.</p>");
+            }
+        </script>
+    </div>
+</body>
+</html>

--- a/src/main/resources/templates/logout.html
+++ b/src/main/resources/templates/logout.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Logout</title>
+</head>
+<body>
+<h1>로그아웃되었습니다.</h1>
+<a href="/">홈으로 돌아가기</a>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣연관된 이슈

> 카카오 로그인 API 연동 #1 

## 📝작업 내용

> 카카오 로그인 API 연동
- 카카오 OAuth2 인증을 통해 사용자가 웹서비스에 로그인할 수 있도록 설정합니다.
- DB 설계 확정 전이므로 사용자 정보를 별도로 저장하지 않고, 인증 흐름만 먼저 구현합니다.
- 백엔드에서의 카카오 로그인 API 연결 테스트를 위하여 
`src/main/resources/templates/`에 테스트용 html 파일을 만들었습니다.

### 스크린샷 (선택)
<img width="1308" alt="스크린샷 2025-02-14 오후 11 37 14" src="https://github.com/user-attachments/assets/31132d28-ff97-4225-9443-2de171d691ff" />
<img width="1307" alt="스크린샷 2025-02-14 오후 11 37 30" src="https://github.com/user-attachments/assets/e4c67a43-4acf-4182-bb4e-c3333ad7a0c4" />
<img width="1314" alt="스크린샷 2025-02-14 오후 11 37 42" src="https://github.com/user-attachments/assets/4e950544-b15c-496c-9bf7-3d2d043026c7" />
<img width="1344" alt="스크린샷 2025-02-14 오후 11 37 53" src="https://github.com/user-attachments/assets/f2ca08ba-ac9e-4142-b5fd-7f2fccd21d07" />