### PR TITLE
Refactor and Fix: imports 복구 및 파일명 수정

### DIFF
--- a/src/main/java/com/untitled/cherrymap/config/SecurityConfig.java
+++ b/src/main/java/com/untitled/cherrymap/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.untitled.cherrymap.config;
 
 import com.untitled.cherrymap.service.KakaoOAuth2MemberService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -8,13 +9,10 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final KakaoOAuth2MemberService kakaoOAuth2MemberService;
-
-    public SecurityConfig(KakaoOAuth2MemberService kakaoOAuth2MemberService) {
-        this.kakaoOAuth2MemberService = kakaoOAuth2MemberService;
-    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/untitled/cherrymap/controller/FrontendApiController.java
+++ b/src/main/java/com/untitled/cherrymap/controller/FrontendApiController.java
@@ -1,5 +1,7 @@
 package com.untitled.cherrymap.controller;
 
+import com.untitled.cherrymap.domain.Member;
+import com.untitled.cherrymap.repository.MemberRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;

--- a/src/main/java/com/untitled/cherrymap/controller/MemberController.java
+++ b/src/main/java/com/untitled/cherrymap/controller/MemberController.java
@@ -11,11 +11,11 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Map;
 
 @RestController
-public class FrontendApiController {
+public class MemberController {
 
     private final MemberRepository memberRepository;
 
-    public FrontendApiController(MemberRepository memberRepository) {
+    public MemberController(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }
 

--- a/src/main/java/com/untitled/cherrymap/service/KakaoOAuth2MemberService.java
+++ b/src/main/java/com/untitled/cherrymap/service/KakaoOAuth2MemberService.java
@@ -1,4 +1,7 @@
 package com.untitled.cherrymap.service;
+
+import com.untitled.cherrymap.domain.Member;
+import com.untitled.cherrymap.repository.MemberRepository;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

- Import 복구: `Member.java`와 `MemberRepository.java` 취합 작업 중 누락되었던 import 복구
(`FrontendApiController` & `KakaoOAuth2MemberService`)
- 파일명 변경: 기존 `FrontendApiController.java`를 `MemberController.java`로 변경.
---
### 기타 refactor 사항
- SecurityConfig.java: 기존 생성자를 lombok 어노테이션으로 대치.

