### PR TITLE
Feat:Refactor:Fix: Member&Route 관련 기능 완성, 카카오 로그인 api 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.security:spring-security-oauth2-jose'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0" // Swagger UI
 }
 

--- a/src/main/java/com/untitled/cherrymap/controller/MemberController.java
+++ b/src/main/java/com/untitled/cherrymap/controller/MemberController.java
@@ -1,40 +1,22 @@
 package com.untitled.cherrymap.controller;
 
 import com.untitled.cherrymap.domain.Member;
-import com.untitled.cherrymap.repository.MemberRepository;
+import com.untitled.cherrymap.service.MemberService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Map;
-
 @RestController
+@RequiredArgsConstructor
 public class MemberController {
 
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
-    public MemberController(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
-    }
-
-    @GetMapping("/{memberId}/info")
-    public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal OAuth2User user) {
-        if (user == null) {
-            return ResponseEntity.badRequest().body("User not authenticated");
-        }
-
-        String providerId = user.getAttribute("id");
-        Member member = memberRepository.findByProviderId(providerId);
-
-        if (member == null) {
-            return ResponseEntity.notFound().build();
-        }
-
-        return ResponseEntity.ok(Map.of(
-                "nickname", member.getNickname(),
-                "email", member.getEmail()
-        ));
+    @GetMapping("/api/{providerId}/info")
+    public ResponseEntity<Member> getMember(@PathVariable String providerId) {
+        Member member = memberService.getMemberByProviderId(providerId);
+        return ResponseEntity.ok().body(member);
     }
 }

--- a/src/main/java/com/untitled/cherrymap/controller/MemberController.java
+++ b/src/main/java/com/untitled/cherrymap/controller/MemberController.java
@@ -2,6 +2,8 @@ package com.untitled.cherrymap.controller;
 
 import com.untitled.cherrymap.domain.Member;
 import com.untitled.cherrymap.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,10 +12,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name="Member-Controller",description = "유저 정보 조회 API")
 public class MemberController {
 
     private final MemberService memberService;
 
+    @Operation(summary = "사용자 정보 요청", description = "providerId에 해당하는 유저 정보를 json 형태로 반환.")
     @GetMapping("/api/{providerId}/info")
     public ResponseEntity<Member> getMember(@PathVariable String providerId) {
         Member member = memberService.getMemberByProviderId(providerId);

--- a/src/main/java/com/untitled/cherrymap/controller/RouteController.java
+++ b/src/main/java/com/untitled/cherrymap/controller/RouteController.java
@@ -1,0 +1,58 @@
+package com.untitled.cherrymap.controller;
+
+import com.untitled.cherrymap.domain.Route;
+import com.untitled.cherrymap.dto.RouteCreateRequest;
+import com.untitled.cherrymap.service.RouteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/{providerId}/routes")
+@Tag(name="Route-Controller",description = "경로 관리 API")
+public class RouteController {
+
+    private final RouteService routeService;
+
+    // 경로 추가
+    @Operation(summary = "경로 추가", description = "providerId에 해당하는 유저의 새로운 경로 저장")
+    @PostMapping("")
+    public ResponseEntity<Void> createRoute(@PathVariable("providerId") String providerId,
+                                            @RequestBody @Valid RouteCreateRequest request) {
+        Long routeId = routeService.createRoute(request, providerId);
+        return ResponseEntity.created(URI.create("routes/"+routeId)).build();
+    }
+
+    // 저장된 모든 경로 탐색
+    @Operation(summary = "저장된 모든 경로 요청", description = "providerId에 해당하는 유저의 모든 저장 경로 리턴.")
+    @GetMapping("/list")
+    public ResponseEntity<List<Route>> getAllRoute(@PathVariable String providerId) {
+        // Service 계층에서 이미 처리된 결과를 반환받음
+        List<Route> routeList = routeService.getAllRoute(providerId);
+        return ResponseEntity.ok(routeList);
+    }
+
+    // 특정 저장 경로 탐색
+    @Operation(summary = "특정 저장 경로 요청", description = "routeId에 해당하는 경로 정보 리턴.")
+    @GetMapping("/{routeId}")
+    public ResponseEntity<Route> getOneRoute(@PathVariable String providerId, @PathVariable Long routeId) {
+        Route route = routeService.getOneRoute(providerId, routeId);
+        System.out.println("getOneRoute 호출됨: providerId = " + providerId + ", routeId = " + routeId);
+        return ResponseEntity.ok(route);
+    }
+
+    // 경로 삭제
+    @Operation(summary = "경로 삭제", description = "routeId에 해당하는 경로 삭제.")
+    @DeleteMapping("/{routeId}")
+    public ResponseEntity<Void> deleteRoute(@PathVariable String providerId, @PathVariable Long routeId) {
+        routeService.deleteRoute(providerId, routeId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/untitled/cherrymap/domain/Member.java
+++ b/src/main/java/com/untitled/cherrymap/domain/Member.java
@@ -15,18 +15,23 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
     @Schema(description = "사용자 ID")
     private Long id;
 
-    @Column(nullable = false, length = 50)
+    @Column(name = "nickname", nullable = false, length = 10)
     @Schema(description = "사용자 닉네임", example = "cherryUser")
     private String nickname;
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(name = "email", nullable = false, unique = true)
     @Schema(description = "사용자 이메일", example = "user@example.com")
     private String email;
 
-    @Column(nullable = false, unique = true, length = 50)
+    @Column(name = "provider_id", nullable = false, unique = true)
     @Schema(description = "소셜 로그인 제공자의 고유 ID", example = "kakao_123456789")
     private String providerId; // 카카오 고유 ID
+
+    @Column(name = "phone_number", length = 20)
+    @Schema(description = "사용자 비상 연락처", example = "010-1234-5678")
+    private String phoneNumber;
 }

--- a/src/main/java/com/untitled/cherrymap/domain/Route.java
+++ b/src/main/java/com/untitled/cherrymap/domain/Route.java
@@ -8,44 +8,47 @@ import lombok.*;
 @Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Table(name = "route")
 @Schema(description = "사용자의 경로 정보 엔티티")
 public class Route {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "route_id")
     @Schema(description = "경로 ID")
-    private Long routeId;
+    private Long id;
 
     @ManyToOne
     @JoinColumn(name = "member_id", nullable = false)
     @Schema(description = "사용자 정보 (회원 ID)")
     private Member member;
 
-    @Column(nullable = false, length = 20)
+    @Column(name = "route_name", nullable = false, length = 20)
     @Schema(description = "경로 이름", example = "홍익대학교")
     private String routeName;
 
-    @Column(nullable = false, length = 20)
+    @Column(name = "start_name", nullable = false, length = 20)
     @Schema(description = "출발지 이름", example = "강남역")
     private String startName;
 
-    @Column(nullable = false)
+    @Column(name = "start_lat", nullable = false)
     @Schema(description = "출발지 위도", example = "37.4979")
     private double startLat;
 
-    @Column(nullable = false)
+    @Column(name = "start_lng", nullable = false)
     @Schema(description = "출발지 경도", example = "127.0276")
     private double startLng;
 
-    @Column(nullable = false, length = 20)
+    @Column(name = "end_name", nullable = false, length = 20)
     @Schema(description = "도착지 이름", example = "서울역")
     private String endName;
 
-    @Column(nullable = false)
+    @Column(name = "end_lat", nullable = false)
     @Schema(description = "도착지 위도", example = "37.5547")
     private double endLat;
 
-    @Column(nullable = false)
+    @Column(name = "end_lng", nullable = false)
     @Schema(description = "도착지 경도", example = "126.9706")
     private double endLng;
 }

--- a/src/main/java/com/untitled/cherrymap/dto/RouteCreateRequest.java
+++ b/src/main/java/com/untitled/cherrymap/dto/RouteCreateRequest.java
@@ -1,0 +1,34 @@
+package com.untitled.cherrymap.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+
+@Getter
+public class RouteCreateRequest {
+
+    @NotNull(message = "경로명은 반드시 포함되어야 합니다.")
+    @Length(max = 20, message = "경로명은 20자를 넘기지 마시오.")
+    private String routeName;
+
+    @NotNull(message = "출발지명은 반드시 포함되어야 합니다.")
+    @Length(max = 20, message = "출발지명은 20자를 넘기지 마시오.")
+    private String startName;
+
+    @NotNull(message = "시작 지점 위도는 반드시 포함되어야 합니다.")
+    private double startLat;
+
+    @NotNull(message = "시작 지점 경도는 반드시 포함되어야 합니다.")
+    private double startLng;
+
+    @NotNull(message = "목적지명은 반드시 포함되어야 합니다.")
+    @Length(max = 20, message = "목적지명은 20자를 넘기지 마시오.")
+    private String endName;
+
+    @NotNull(message = "도착 지점 위도는 반드시 포함되어야 합니다.")
+    private double endLat;
+
+    @NotNull(message = "도착 지점 경도는 반드시 포함되어야 합니다.")
+    private double endLng;
+}

--- a/src/main/java/com/untitled/cherrymap/repository/RouteRepository.java
+++ b/src/main/java/com/untitled/cherrymap/repository/RouteRepository.java
@@ -1,7 +1,10 @@
 package com.untitled.cherrymap.repository;
 
+import com.untitled.cherrymap.domain.Member;
 import com.untitled.cherrymap.domain.Route;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {
+    List<Route> findAllByMember(Member member);
 }

--- a/src/main/java/com/untitled/cherrymap/service/KakaoOAuth2MemberService.java
+++ b/src/main/java/com/untitled/cherrymap/service/KakaoOAuth2MemberService.java
@@ -43,6 +43,7 @@ public class KakaoOAuth2MemberService extends DefaultOAuth2UserService {
                     .providerId(providerId)
                     .nickname(nickname)
                     .email(email)
+                    .phoneNumber(null)
                     .build();
             System.out.println("새 사용자 등록: " + nickname + " (" + email + ")");
         } else {

--- a/src/main/java/com/untitled/cherrymap/service/MemberService.java
+++ b/src/main/java/com/untitled/cherrymap/service/MemberService.java
@@ -1,0 +1,23 @@
+package com.untitled.cherrymap.service;
+
+import com.untitled.cherrymap.domain.Member;
+import com.untitled.cherrymap.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Member getMemberByProviderId(String providerId) {
+        Member member = memberRepository.findByProviderId(providerId);
+        if (member == null) {
+            throw new RuntimeException("Member not found with providerId: " + providerId);
+        }
+        return member;
+    }
+}

--- a/src/main/java/com/untitled/cherrymap/service/RouteService.java
+++ b/src/main/java/com/untitled/cherrymap/service/RouteService.java
@@ -1,0 +1,83 @@
+package com.untitled.cherrymap.service;
+
+import com.untitled.cherrymap.domain.Member;
+import com.untitled.cherrymap.domain.Route;
+import com.untitled.cherrymap.dto.RouteCreateRequest;
+import com.untitled.cherrymap.repository.MemberRepository;
+import com.untitled.cherrymap.repository.RouteRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RouteService {
+
+    private final RouteRepository routeRepository;
+    private final MemberRepository memberRepository;
+
+    // 경로 생성
+    @Transactional
+    public Long createRoute(RouteCreateRequest request, String providerId) {
+        Member member = memberRepository.findByProviderId(providerId);
+        if (member == null) {
+            throw new RuntimeException("Member not found with providerId: " + providerId);
+        }
+
+        Route route = Route.builder().member(member)
+                .routeName(request.getRouteName())
+                .startName(request.getStartName())
+                .startLat(request.getStartLat())
+                .startLng(request.getStartLng())
+                .endName(request.getEndName())
+                .endLat(request.getEndLat())
+                .endLng(request.getEndLng())
+                .build();
+        routeRepository.save(route);
+
+        return route.getId();
+    }
+    // 전체 경로 조회
+    @Transactional(readOnly = true)
+    public List<Route> getAllRoute(String providerId) {
+        Member member = memberRepository.findByProviderId(providerId);
+        if (member == null) {
+            throw new RuntimeException("Member not found with providerId: " + providerId);
+        }
+        return routeRepository.findAllByMember(member);
+    }
+
+    // 특정 경로 조회
+    @Transactional(readOnly = true)
+    public Route getOneRoute(String providerId, Long routeId) {
+        return validateMemberAndGetRoute(providerId, routeId);
+    }
+
+    // 경로 삭제
+    @Transactional
+    public void deleteRoute(String providerId, Long routeId) {
+        Route route = validateMemberAndGetRoute(providerId, routeId);
+        routeRepository.delete(route);
+    }
+    // 유저의 권한 확인 및 특정 경로 탐색
+    private Route validateMemberAndGetRoute(String providerId, Long routeId) {
+        Member member = memberRepository.findByProviderId(providerId);
+        System.out.println("조회된 Member: " + member);
+        if (member == null) {
+            throw new RuntimeException("Member not found with providerId: " + providerId);
+        }
+
+        Route route = routeRepository.findById(routeId)
+                .orElseThrow(() -> new EntityNotFoundException("Route not found with id: " + routeId));
+        System.out.println("조회된 Route: " + route);
+        if (!member.equals(route.getMember())) {
+            throw new RuntimeException("Access denied: Member with providerId " + providerId
+                    + " does not own Route with id: " + routeId);
+        }
+        return route;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,6 +26,11 @@ spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/o
 spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 
+# json 형태의 에러 메세지 반환
+server.error.include-message=always
+server.error.include-binding-errors=always
+server.error.whitelabel.enabled=false
+
 
 springdoc.packages-to-scan=com.untitled.cherrymap
 springdoc.default-consumes-media-type=application/json;charset=UTF-8

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <h1>카카오 로그인</h1>
-    <a href="/oauth2/authorization/kakao">
+    <a href="/api/oauth2/authorization/kakao">
         <button>카카오로 로그인</button>
     </a>
     <!-- 로그인 오류 메시지 표시 -->


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #9 #10

## 📝작업 내용
- 카카오 로그인 api 연결 오류 수정 및 관련 코드 수정
- Member & Route의 엔티티~컨트롤러 계층 구현
- swagger.ui를 통한 MemberController, RouteController 명세 문서화 작업 준비(어노테이션 추가)

## DB 테스트 세팅
![image](https://github.com/user-attachments/assets/0e6f031d-a99e-437b-ad0c-ff61a44f8812)
![image](https://github.com/user-attachments/assets/cef25da3-4b5c-497c-8d0f-7959f576d6ab)

## API 가이드라인
<img width="723" alt="cherry_logout" src="https://github.com/user-attachments/assets/c2e28232-6bbd-48de-8e4c-09dee7db71ea" />
<img width="1010" alt="cherry_addRoute" src="https://github.com/user-attachments/assets/d145185f-875c-4396-92b7-f6c338535e1e" />
<img width="1016" alt="cherry_getAllRoute" src="https://github.com/user-attachments/assets/684e5c20-a0e7-4636-a8b8-c3b494ff4359" />
<img width="1014" alt="cherry_specificRoute" src="https://github.com/user-attachments/assets/cda2c1ad-7b26-4a73-bb23-7935acf618d1" />
<img width="1012" alt="cherry_deleteRoute" src="https://github.com/user-attachments/assets/c0aac547-3494-4b3b-bf0f-0cd29e50d763" />

