### PR TITLE
Fix: API 오류 시 카카오 인증 URL로 리다이렉션하는 문제 해결

### DIFF
--- a/src/main/java/com/untitled/cherrymap/config/SecurityConfig.java
+++ b/src/main/java/com/untitled/cherrymap/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.untitled.cherrymap.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.untitled.cherrymap.service.KakaoOAuth2MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -9,13 +8,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.access.AccessDeniedHandler;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
@@ -31,35 +28,47 @@ public class SecurityConfig {
                         .ignoringRequestMatchers("/api/**", "/api/login/oauth2/**", "/api/logout", "/api/error")
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll() // ✅ 모든 요청을 인증 없이 허용
+                        .anyRequest().permitAll() // 모든 요청을 인증 없이 허용
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        .authorizationEndpoint(authEndpoint -> authEndpoint
-                                .baseUri("/api/oauth2/authorization")
-                        )
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(kakaoOAuth2MemberService)
                         )
-                        .successHandler((request, response, authentication) -> {
-                            response.setStatus(200);
-                            response.setContentType("application/json");
-                            response.setCharacterEncoding("UTF-8");
-                            response.getWriter().write("{\"message\": \"Login successful\"}");
-                        })
+                        .successHandler(this::handleLoginSuccess) // 로그인 성공 시 providerId로 리다이렉트
                 )
                 .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // ✅ 세션 사용 안 함
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 사용 안 함
                 )
                 .logout(logout -> logout
                         .logoutUrl("/api/logout")
-                        .logoutSuccessHandler((request, response, authentication) -> {
-                            response.setStatus(200);
-                            response.setContentType("application/json");
-                            response.setCharacterEncoding("UTF-8");
-                            response.getWriter().write("{\"message\": \"Logout successful\"}");
-                        })
+                        .logoutSuccessHandler(this::handleLogoutSuccess) // 로그아웃 후 리다이렉트
                 );
 
         return http.build();
+    }
+    // 로그인 성공 후 providerId를 가져와서 /{providerId}/home으로 리다이렉트
+    private void handleLoginSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Authentication principal is null");
+            return;
+        }
+
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        // providerId 가져오기
+        String providerId = attributes.getOrDefault("id", "Unknown").toString();
+        if (providerId.equals("Unknown")) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Provider ID is missing");
+            return;
+        }
+
+        String redirectUrl = "/" + providerId + "/home";
+        response.sendRedirect(redirectUrl);
+    }
+
+    // 로그아웃 성공 후 /logout-success로 리다이렉트
+    private void handleLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        response.sendRedirect("/logout-success");
     }
 }

--- a/src/main/java/com/untitled/cherrymap/controller/ThymeleafTestController.java
+++ b/src/main/java/com/untitled/cherrymap/controller/ThymeleafTestController.java
@@ -1,28 +1,21 @@
 package com.untitled.cherrymap.controller;
 
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 // 웹브라우저를 통한 카카오 로그인 api 테스트 목적으로 만든 테스트용 컨트롤러(프론트에 제공하지 않음)
 @Controller
 @Profile("dev") // 개발 환경에서만 활성화
 public class ThymeleafTestController {
 
-    @GetMapping("/{memberId}/home")
-    public String testHomePage(Model model, @AuthenticationPrincipal OAuth2User user) {
-        System.out.println("User Attributes: " + user.getAttributes()); // 전체 속성 출력 for logging
-        String nickname = user.getAttribute("nickname");
-        String email = user.getAttribute("email");
+    @GetMapping("/{providerId}/home")
+    public String testHomePage(@PathVariable String providerId, Model model) {
+        System.out.println("Provider ID: " + providerId); // providerId 로깅
 
-        System.out.println("Nickname: " + nickname); // 닉네임 출력 for logging
-        System.out.println("Email: " + email);       // 이메일 출력 for logging
-
-        model.addAttribute("nickname", nickname);
-        model.addAttribute("email", email);
+        model.addAttribute("providerId", providerId); // providerId 전달
         return "home"; // home.html 렌더링
     }
 

--- a/src/main/java/com/untitled/cherrymap/service/KakaoOAuth2MemberService.java
+++ b/src/main/java/com/untitled/cherrymap/service/KakaoOAuth2MemberService.java
@@ -23,6 +23,10 @@ public class KakaoOAuth2MemberService extends DefaultOAuth2UserService {
         OAuth2User oAuth2User = super.loadUser(userRequest);
         Map<String, Object> attributes = oAuth2User.getAttributes();
 
+        if (attributes == null || !attributes.containsKey("id")) {
+            throw new IllegalStateException("Invalid Kakao response: missing id");
+        }
+
         // 카카오 계정 정보 추출
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> profile = kakaoAccount != null ? (Map<String, Object>) kakaoAccount.get("profile") : null;
@@ -53,16 +57,10 @@ public class KakaoOAuth2MemberService extends DefaultOAuth2UserService {
         }
         memberRepository.save(member);
 
-        // 사용자 정보를 DefaultOAuth2User로 반환
-        Map<String, Object> customAttributes = Map.of(
-                "id", providerId,
-                "nickname", member.getNickname(),
-                "email", member.getEmail()
-        );
-
+        // providerId를 인증 객체의 Principal로 설정
         return new DefaultOAuth2User(
                 oAuth2User.getAuthorities(),
-                customAttributes,
+                attributes,
                 "id"
         );
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,11 +26,8 @@ spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/o
 spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
 spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 
-# json 형태의 에러 메세지 반환
-server.error.include-message=always
-server.error.include-binding-errors=always
-server.error.whitelabel.enabled=false
-
+# 오류 시 trace 필드를 없애고 오류 메시지만 반환
+server.error.include-stacktrace=never
 
 springdoc.packages-to-scan=com.untitled.cherrymap
 springdoc.default-consumes-media-type=application/json;charset=UTF-8

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -7,7 +7,6 @@
   <title>Home</title>
 </head>
 <body>
-  <h1>Welcome, <span th:text="${nickname}">[nickname is empty]</span>!</h1>
-  <p>Your email is: <span th:text="${email}">[email is empty]</span></p>
+  <h1>Welcome, <span th:text="${providerId}">[providerId is empty]</span>!</h1>
 </body>
 </html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <h1>카카오 로그인</h1>
-    <a href="/api/oauth2/authorization/kakao">
+    <a href="/oauth2/authorization/kakao">
         <button>카카오로 로그인</button>
     </a>
     <!-- 로그인 오류 메시지 표시 -->


### PR DESCRIPTION
## #️⃣연관된 이슈
> #16 

## 📝작업 내용

- API 요청 오류 시 원하는 예외 처리를 리턴하지 않고 카카오 로그인 인증 URL로 리다이렉션 하는 문제를 해결.
- 프론트엔드의 API 요청 오류 시 리턴하는 응답 json 중 trace 필드를 제거(단, 백엔드에서는 여전히 trace 확인 가능).

## 스크린샷
<img width="1009" alt="image" src="https://github.com/user-attachments/assets/ce29f025-9bce-4b16-a993-af36a77d4c8d" />
