### PR TITLE
refactor: 테이블 생성하지 않기 위해 AlertMesaageRepository 삭제

### DIFF
--- a/src/main/java/com/untitled/cherrymap/repository/AlertMessageRepository.java
+++ b/src/main/java/com/untitled/cherrymap/repository/AlertMessageRepository.java
@@ -1,8 +1,0 @@
-package com.untitled.cherrymap.repository;
-
-import com.untitled.cherrymap.domain.AlertMessage;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface AlertMessageRepository extends JpaRepository<AlertMessage, Long> {
-    AlertMessage findByMode(String mode);
-}


### PR DESCRIPTION
## 📝작업 내용

> AlertMessage가 JPA 엔티티가 아니고 테이블도 생성하지 않을 계획이라면, AlertMessageRepository는 삭제해야함

