### PR TITLE
Feat:Refactor: 예외 처리 패키지 추가 및 Route 엔티티 필드 mode 추가 

### DIFF
--- a/src/main/java/com/untitled/cherrymap/domain/Route.java
+++ b/src/main/java/com/untitled/cherrymap/domain/Route.java
@@ -28,6 +28,10 @@ public class Route {
     @Schema(description = "경로 이름", example = "홍익대학교")
     private String routeName;
 
+    @Column(name = "mode", nullable = false, length = 10)
+    @Schema(description = "경로 유형: 도보 or 대중교통", example = "대중교통")
+    private String mode;
+
     @Column(name = "start_name", nullable = false, length = 20)
     @Schema(description = "출발지 이름", example = "강남역")
     private String startName;

--- a/src/main/java/com/untitled/cherrymap/dto/RouteCreateRequest.java
+++ b/src/main/java/com/untitled/cherrymap/dto/RouteCreateRequest.java
@@ -1,6 +1,7 @@
 package com.untitled.cherrymap.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
@@ -14,6 +15,11 @@ public class RouteCreateRequest {
     @Length(max = 20, message = "경로명은 20자를 넘기지 마시오.")
     @Schema(description = "경로 이름", example = "홍익대학교")
     private String routeName;
+
+    @NotNull(message = "모드(도보 or 대중교통)은 반드시 포함되어야 합니다.")
+    @Length(max = 10, message = "모드는 10자를 넘기지 마시오.")
+    @Schema(description = "경로 유형: 도보 or 대중교통", example = "대중교통")
+    private String mode;
 
     @NotNull(message = "출발지명은 반드시 포함되어야 합니다.")
     @Length(max = 20, message = "출발지명은 20자를 넘기지 마시오.")

--- a/src/main/java/com/untitled/cherrymap/dto/RouteCreateRequest.java
+++ b/src/main/java/com/untitled/cherrymap/dto/RouteCreateRequest.java
@@ -1,34 +1,43 @@
 package com.untitled.cherrymap.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
 
 
 @Getter
+@Schema(description = "경로 저장 시 RequestBody DTO(JSON)")
 public class RouteCreateRequest {
 
     @NotNull(message = "경로명은 반드시 포함되어야 합니다.")
     @Length(max = 20, message = "경로명은 20자를 넘기지 마시오.")
+    @Schema(description = "경로 이름", example = "홍익대학교")
     private String routeName;
 
     @NotNull(message = "출발지명은 반드시 포함되어야 합니다.")
     @Length(max = 20, message = "출발지명은 20자를 넘기지 마시오.")
+    @Schema(description = "출발지 이름", example = "강남역")
     private String startName;
 
     @NotNull(message = "시작 지점 위도는 반드시 포함되어야 합니다.")
+    @Schema(description = "출발지 위도", example = "37.4979")
     private double startLat;
 
     @NotNull(message = "시작 지점 경도는 반드시 포함되어야 합니다.")
+    @Schema(description = "출발지 경도", example = "127.0276")
     private double startLng;
 
     @NotNull(message = "목적지명은 반드시 포함되어야 합니다.")
     @Length(max = 20, message = "목적지명은 20자를 넘기지 마시오.")
+    @Schema(description = "도착지 이름", example = "서울역")
     private String endName;
 
     @NotNull(message = "도착 지점 위도는 반드시 포함되어야 합니다.")
+    @Schema(description = "도착지 위도", example = "37.5547")
     private double endLat;
 
     @NotNull(message = "도착 지점 경도는 반드시 포함되어야 합니다.")
+    @Schema(description = "도착지 경도", example = "126.9706")
     private double endLng;
 }

--- a/src/main/java/com/untitled/cherrymap/exception/BadDataAccessException.java
+++ b/src/main/java/com/untitled/cherrymap/exception/BadDataAccessException.java
@@ -1,0 +1,7 @@
+package com.untitled.cherrymap.exception;
+
+public class BadDataAccessException extends RuntimeException {
+    public BadDataAccessException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/untitled/cherrymap/exception/BadRequestException.java
+++ b/src/main/java/com/untitled/cherrymap/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.untitled.cherrymap.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/untitled/cherrymap/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/untitled/cherrymap/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.untitled.cherrymap.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<Map<String, Object>> handleBadRequestException(BadRequestException ex) {
+        Map<String, Object> errorBody = new HashMap<>();
+        errorBody.put("timestamp", LocalDateTime.now());
+        errorBody.put("status", HttpStatus.BAD_REQUEST.value());
+        errorBody.put("error", "Bad Request");
+        errorBody.put("message", ex.getMessage());
+
+        return ResponseEntity.badRequest().body(errorBody);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleGenericException(Exception ex) {
+        Map<String, Object> errorBody = new HashMap<>();
+        errorBody.put("timestamp", LocalDateTime.now());
+        errorBody.put("status", HttpStatus.INTERNAL_SERVER_ERROR.value());
+        errorBody.put("error", "Internal Server Error");
+        errorBody.put("message", ex.getMessage());
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorBody);
+    }
+}

--- a/src/main/java/com/untitled/cherrymap/message/ErrorMessage.java
+++ b/src/main/java/com/untitled/cherrymap/message/ErrorMessage.java
@@ -1,0 +1,8 @@
+package com.untitled.cherrymap.message;
+
+public class ErrorMessage {
+    public static final String MEMBER_NOT_FOUND_WITH = "Member not found with providerId: ";
+    public static final String ROUTE_NOT_FOUND_WITH = "Route not found with id: ";
+    public static final String DUPLICATE_ROUTE = "The route already exists.";
+    public static final String ACCESS_DENIED = "Member does not have permission to access this route.";
+}

--- a/src/main/java/com/untitled/cherrymap/repository/RouteRepository.java
+++ b/src/main/java/com/untitled/cherrymap/repository/RouteRepository.java
@@ -3,8 +3,18 @@ package com.untitled.cherrymap.repository;
 import com.untitled.cherrymap.domain.Member;
 import com.untitled.cherrymap.domain.Route;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 
 public interface RouteRepository extends JpaRepository<Route, Long> {
     List<Route> findAllByMember(Member member);
+
+    @Query("SELECT COUNT(r) > 0 FROM Route r WHERE r.mode = :mode AND r.startLat = :startLat AND r.startLng = :startLng " +
+            "AND r.endLat = :endLat AND r.endLng = :endLng")
+    boolean existsByRouteDetails(@Param("mode") String mode,
+                                 @Param("startLat") double startLat, @Param("startLng") double startLng,
+                                 @Param("endLat") double endLat, @Param("endLng") double endLng);
+
 }

--- a/src/main/java/com/untitled/cherrymap/service/KakaoOAuth2MemberService.java
+++ b/src/main/java/com/untitled/cherrymap/service/KakaoOAuth2MemberService.java
@@ -49,11 +49,11 @@ public class KakaoOAuth2MemberService extends DefaultOAuth2UserService {
                     .email(email)
                     .phoneNumber(null)
                     .build();
-            System.out.println("새 사용자 등록: " + nickname + " (" + email + ")");
+            //System.out.println("새 사용자 등록: " + nickname + " (" + email + ")");
         } else {
             member.setNickname(nickname);
             member.setEmail(email);
-            System.out.println("기존 사용자 업데이트: " + nickname + " (" + email + ")");
+            //System.out.println("기존 사용자 업데이트: " + nickname + " (" + email + ")");
         }
         memberRepository.save(member);
 

--- a/src/main/java/com/untitled/cherrymap/service/MemberService.java
+++ b/src/main/java/com/untitled/cherrymap/service/MemberService.java
@@ -1,6 +1,8 @@
 package com.untitled.cherrymap.service;
 
 import com.untitled.cherrymap.domain.Member;
+import com.untitled.cherrymap.exception.BadRequestException;
+import com.untitled.cherrymap.message.ErrorMessage;
 import com.untitled.cherrymap.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +18,7 @@ public class MemberService {
     public Member getMemberByProviderId(String providerId) {
         Member member = memberRepository.findByProviderId(providerId);
         if (member == null) {
-            throw new RuntimeException("Member not found with providerId: " + providerId);
+            throw new BadRequestException(ErrorMessage.MEMBER_NOT_FOUND_WITH + providerId);
         }
         return member;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #4 #14 

## 📝작업 내용
- 예외 처리 패키지 추가
  - 커스텀 예외 처리 추가
  - 예외 메세지 클래스 추가
  - 경로 저장시 중복 저장 예외 처리 추가

- Route 엔티티 필드 mode 추가
  - '도보' 또는 '대중교통'
  - varchar(10)
- RouteCreateRequest swagger.ui 적용 위한 어노테이션 추가


### 스크린샷
- Route 테이블 예시

![image](https://github.com/user-attachments/assets/3b32833f-102a-42ad-9fdc-70fab45641a9)

- 에러 정상 리턴 테스트
<img width="709" alt="image" src="https://github.com/user-attachments/assets/d71598aa-158b-4d13-95a2-6bf5e2515403" />

